### PR TITLE
update deps to avoid warning "graceful-fs version 3 and before will f…

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,16 +20,16 @@
     "prepublish": "grunt coffee"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-coffeelint": "0.0.6",
-    "grunt-contrib-coffee": "~0.6.6",
-    "grunt-cli": "~0.1.7",
-    "coffee-script": "~1.6.2",
-    "rimraf": "~2.1.4"
+    "grunt": "~0.4.5",
+    "grunt-coffeelint": "0.0.15",
+    "grunt-contrib-coffee": "~1.0.0",
+    "grunt-cli": "~0.1.13",
+    "coffee-script": "~1.10.0",
+    "rimraf": "~2.5.2"
   },
   "dependencies": {
-    "decompress-zip": "0.1.0",
-    "fs-extra": "0.18.2",
-    "request": "2.55.0"
+    "decompress-zip": "0.2.0",
+    "fs-extra": "0.26.5",
+    "request": "2.69.0"
   }
 }


### PR DESCRIPTION
update deps to avoid warning "graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible."

This package is used in asar, so, it is very annoying.