### PR TITLE
bump decompress-zip to 0.2.1 with newer graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "rimraf": "~2.1.4"
   },
   "dependencies": {
-    "decompress-zip": "0.1.0",
+    "decompress-zip": "0.2.1",
     "fs-extra": "0.18.2",
     "request": "2.55.0"
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "rimraf": "~2.1.4"
   },
   "dependencies": {
-    "decompress-zip": "0.2.1",
+    "decompress-zip": "0.3.0",
     "fs-extra": "0.18.2",
     "request": "2.55.0"
   }


### PR DESCRIPTION
[graceful-fs](http://npm.im/graceful-fs) is spewing deprecation messages all over node-land:

```
npm WARN deprecated graceful-fs@3.0.8: graceful-fs version 3 and before will fail on newer node releases. Please update to graceful-fs@^4.0.0 as soon as possible.
```

```
├─┬ electron-packager@5.2.1
│ └─┬ asar@0.8.3
│   └─┬ mksnapshot@0.1.0
│     └─┬ decompress-zip@0.1.0
│       └── graceful-fs@3.0.8 
```

Once we land this, we can upstream it to `asar` and finally `electron-packager`

@zcbenz @kevinsawicki @jlord 

Related: https://github.com/electron/electron-api-demos/issues/75